### PR TITLE
Fix Lombok equals recursion

### DIFF
--- a/src/main/java/com/gratiStore/api_gratiStore/domain/entities/atendente/Atendente.java
+++ b/src/main/java/com/gratiStore/api_gratiStore/domain/entities/atendente/Atendente.java
@@ -19,7 +19,7 @@ import static com.gratiStore.api_gratiStore.domain.validator.negocio.Validator.*
 @Table(name = "atendentes")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = true, exclude = {"pontos", "loja"})
 public class Atendente extends EntidadeBase {
 
     @Column(name = "nome", nullable = false)
@@ -98,6 +98,7 @@ public class Atendente extends EntidadeBase {
     private BigDecimal salario = BigDecimal.ZERO;
 
     @OneToMany(mappedBy = "atendente")
+    @ToString.Exclude
     private List<PontoEletronico> pontos;
 
     @ManyToOne

--- a/src/main/java/com/gratiStore/api_gratiStore/domain/entities/calculadora/Calculadora.java
+++ b/src/main/java/com/gratiStore/api_gratiStore/domain/entities/calculadora/Calculadora.java
@@ -17,7 +17,7 @@ import static com.gratiStore.api_gratiStore.domain.validator.negocio.Validator.*
 @Table(name = "calculadoras")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = true, exclude = "loja")
 public class Calculadora extends EntidadeBase {
 
     @Column(name = "nome", nullable = false)

--- a/src/main/java/com/gratiStore/api_gratiStore/domain/entities/loja/Loja.java
+++ b/src/main/java/com/gratiStore/api_gratiStore/domain/entities/loja/Loja.java
@@ -20,7 +20,7 @@ import static com.gratiStore.api_gratiStore.domain.validator.negocio.Validator.*
 @Table(name = "lojas")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = true, exclude = {"atendentes", "calculadora"})
 public class Loja extends EntidadeBase {
 
     @Column(name = "nome", nullable = false)

--- a/src/main/java/com/gratiStore/api_gratiStore/domain/entities/ponto/PontoEletronico.java
+++ b/src/main/java/com/gratiStore/api_gratiStore/domain/entities/ponto/PontoEletronico.java
@@ -17,7 +17,7 @@ import static com.gratiStore.api_gratiStore.domain.validator.negocio.PontoEletro
 @Entity
 @Table(name = "pontos_eletronicos")
 @Getter
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = true, exclude = "atendente")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PontoEletronico extends EntidadeBase {
 
@@ -42,6 +42,7 @@ public class PontoEletronico extends EntidadeBase {
 
     @ManyToOne
     @JoinColumn(name = "atendente-id", nullable = false)
+    @ToString.Exclude
     private Atendente atendente;
 
     public PontoEletronico(LocalDate data,

--- a/src/main/java/com/gratiStore/api_gratiStore/domain/entities/resultado/ResultadoHoraExtra.java
+++ b/src/main/java/com/gratiStore/api_gratiStore/domain/entities/resultado/ResultadoHoraExtra.java
@@ -20,13 +20,14 @@ import static com.gratiStore.api_gratiStore.domain.validator.negocio.ResultadoHo
         @UniqueConstraint(columnNames = {"atendente_id", "mes", "ano"})
 })
 @Getter
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = true, exclude = "atendente")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ResultadoHoraExtra extends EntidadeBase {
 
     @ManyToOne
     @JoinColumn(name = "atendente_id", nullable = false)
     @JsonIgnore
+    @ToString.Exclude
     private Atendente atendente;
 
     @Column(name = "mes", nullable = false)


### PR DESCRIPTION
## Summary
- prevent recursive `equals`/`hashCode` by excluding links between entities
- update Atendente, PontoEletronico, Loja, Calculadora and ResultadoHoraExtra

## Testing
- `./mvnw test` *(fails: wget failed to fetch maven due to network)*

------
https://chatgpt.com/codex/tasks/task_e_686fe0d121b8832b9c6b25afd81bdbe6