### PR TITLE
docs: improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,15 @@
 
 API responsável pelo cálculo de gratificações de atendentes com base em desempenho e ranking.
 
+Este projeto compõe meu portfólio e foi desenvolvido com foco em boas práticas, testes automatizados e facilidade de execução por meio de containers.
+
 ## 🚀 Tecnologias principais
 
 - Java 17
 - Spring Boot 3.3.5
 - Spring Data JPA
 - MySQL
-- H2 (para testes)
+- Testcontainers + MySQL (integração de testes)
 - Lombok
 - Docker e Docker Compose
 - Swagger (springdoc-openapi)
@@ -20,6 +22,7 @@ Antes de rodar o projeto, você precisa ter instalado:
 
 - [Docker](https://www.docker.com/)
 - [Docker Compose](https://docs.docker.com/compose/)
+- [Git](https://git-scm.com/)
 
 ## 🛠️ Como rodar o projeto
 
@@ -31,7 +34,7 @@ git clone https://github.com/WaldirJuniorGPN/front-gratiStore
 cd api-gratiStore
 ```
 
-**Importante:** os dois repositórios precisam estar na mesma pasta para que o build funcione corretamente.
+> Os dois repositórios devem estar na mesma pasta para que o build funcione corretamente.
 
 ### 2. Suba os containers
 
@@ -41,28 +44,29 @@ Execute o seguinte comando na raiz do projeto `api-gratiStore`:
 docker-compose up --build
 ```
 
-O Docker Compose irá subir 3 containers:
+O Docker Compose irá subir três containers:
 
-- `mysql-ms`: container do MySQL (porta 3307)
+- `mysql-ms`: banco de dados MySQL (porta 3307)
 - `api-gratiStore`: back-end da aplicação (porta 8080)
 - `front-gratiStore`: front-end da aplicação (porta 5500)
-
-> ⚠️ **Importante:** o container `api-gratiStore` depende do `mysql-ms`. Certifique-se de que o banco de dados esteja pronto antes do Spring Boot tentar iniciar. Caso contrário, o back-end poderá falhar na conexão com o banco. O `docker-compose` já cuida da ordem de inicialização com a diretiva `depends_on`, mas em ambientes mais lentos, pode ser necessário aguardar manualmente a inicialização completa do MySQL.
 
 ### 3. Acesse a aplicação
 
 - Front-end: [http://localhost:5500](http://localhost:5500)
 - API Swagger UI: [http://localhost:8080/swagger-ui.html](http://localhost:8080/swagger-ui.html)
 
-## 🧪 Rodando os testes
+## 🧪 Testes
 
-Os testes utilizam o banco de dados em memória H2.
+Os testes utilizam **Testcontainers** com um banco MySQL efêmero, aproximando o ambiente de desenvolvimento do cenário real. Para executá-los, certifique-se de que o Docker esteja em funcionamento e rode:
 
 ```bash
 ./mvnw test
 ```
 
+## 🤝 Contribuição
+
+Sinta-se à vontade para abrir issues ou enviar pull requests. Toda ajuda é bem-vinda!
+
 ---
 
-Se tiver qualquer dúvida ou sugestão, fique à vontade para abrir uma issue ou contribuir! 😄
-
+Caso tenha dúvidas ou sugestões, estou à disposição. 😄


### PR DESCRIPTION
## Summary
- rewrite README to highlight Testcontainers-based MySQL testing

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b63f004c80832bbb8c4580b0accfde